### PR TITLE
Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.25'
         check-latest: true
 
     - name: Check out code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Verify Go module setup
       run: |
@@ -54,7 +54,7 @@ jobs:
       shell: bash
 
     - name: Install golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
       with:
         version: v2.4.0
         install-mode: binary
@@ -70,7 +70,7 @@ jobs:
       shell: bash
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         name: fabricator-${{ matrix.os }}
         path: build/fabricator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
       
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
           check-latest: true
@@ -104,10 +104,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.25'
           check-latest: true
@@ -145,7 +145,7 @@ jobs:
           cp "build/fabricator-$GOOS-$GOARCH${{ matrix.suffix }}" "build/$PLATFORM_NAME${{ matrix.suffix }}"
       
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: fabricator-${{ matrix.goos }}-${{ matrix.goarch }}
           path: build/fabricator-*
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0  # Needed for tag creation
           token: ${{ secrets.GITHUB_TOKEN }}  # Use the GitHub token to authorize tag creation
@@ -188,13 +188,13 @@ jobs:
           git push origin "$VERSION"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
         with:
           path: artifacts
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: "${{ needs.prepare.outputs.version }}"
           name: "Release ${{ needs.prepare.outputs.version }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.25'
         check-latest: true


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs for supply chain security.

## Changes

Actions are pinned to the exact commit matching the version tag. Version preserved as inline comment for readability.

## Context

- Jira: [PRODSEC-132424](https://jira.cs.sys/browse/PRODSEC-132424)
- Pinning reduces supply chain risk by ensuring exact action versions
- Version preserved as comment: `action@<sha> # <version>`

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Confirm pinned SHAs match expected versions

LLM Agent(s) contributed to this PR.