### PR TITLE
Pin GitHub Actions to approved SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         check-latest: true
 
     - name: Check out code
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Verify Go module setup
       run: |
@@ -54,7 +54,7 @@ jobs:
       shell: bash
 
     - name: Install golangci-lint
-      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9 (v9.2.0)
       with:
         version: v2.4.0
         install-mode: binary
@@ -70,7 +70,7 @@ jobs:
       shell: bash
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7 (v7.0.1)
       with:
         name: fabricator-${{ matrix.os }}
         path: build/fabricator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
       
@@ -104,7 +104,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -145,7 +145,7 @@ jobs:
           cp "build/fabricator-$GOOS-$GOARCH${{ matrix.suffix }}" "build/$PLATFORM_NAME${{ matrix.suffix }}"
       
       - name: Upload binary artifact
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7 (v7.0.1)
         with:
           name: fabricator-${{ matrix.goos }}-${{ matrix.goarch }}
           path: build/fabricator-*
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Needed for tag creation
           token: ${{ secrets.GITHUB_TOKEN }}  # Use the GitHub token to authorize tag creation
@@ -188,7 +188,7 @@ jobs:
           git push origin "$VERSION"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8 (v8.0.1)
         with:
           path: artifacts
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6


### PR DESCRIPTION
## Summary

- Pin 9 GitHub Action reference(s) to approved commit SHAs (PRODSEC-132424)
- Actions updated: actions/checkout, actions/download-artifact, actions/upload-artifact, golangci/golangci-lint-action
- No functional change: SHAs resolve to equivalent or newer approved versions

## Test plan

- [ ] Verify CI passes with the new pinned SHAs
- [ ] Confirm all pinned SHAs match the approved allowlist

LLM Agent(s) contributed to this PR.