### PR TITLE
[CONTID-11148] Remove dependabot github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,20 +35,3 @@ updates:
         update-types: ["version-update:semver-major"]
 
   # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 3
-    target-branch: "main"
-    cooldown:
-      default-days: 7
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "deps(actions)"
-    groups:
-      all-actions:
-        patterns:
-          - "*"


### PR DESCRIPTION
Remove github-actions package ecosystem from Dependabot configuration.

GHA versions are explicitly allowlisted and AppSec will reach out when specific vulnerabilities need updates.

Jira: https://jira.cs.sys/browse/CONTID-11148

LLM Agent(s) contributed to this PR.